### PR TITLE
Add google Takeout data dump support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*.js]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.py]
+indent_size = 4
+
+[*.yml]
+indent_size = 4
+indent_style = space

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,2 @@
+[style]
+column_limit=179

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Start your command prompt, shell or terminal, find your download directory and r
 (you may need to use 'pip3' instead of 'pip' if you have both python versions 2 and 3 installed) This will install the additional libraries needed to run KIM. You only need to do this once. If you have Anaconda as your Python base you may need to find tutorials on how to get pip and install dependencies. Advanced users may want to setup a virtual environment for this.
 
 #### Step 4: 
- Keep does not yet have an official API from Google. So, you must first test your Google account login with the Keep library and manually approve access with a browswer. **Be sure you have logged into your primary Google account only in your default browser first before testing the Keep login.**  From within your command prompt or shell and run 
+ Keep does not yet have an official API from Google. So, you must first test your Google account login with the Keep library and manually approve access with a browser. **Be sure you have logged into your primary Google account only in your default browser first before testing the Keep login.**  From within your command prompt or shell and run 
 ```bash
 > python keep-test.py
 ```

--- a/kim.py
+++ b/kim.py
@@ -14,7 +14,6 @@ import click
 from pathlib import Path
 from collections import namedtuple
 
-
 KEEP_CACHE = 'kdata.json'
 KEEP_KEYRING_ID = 'google-keep-token'
 KEEP_NOTE_URL = "https://keep.google.com/#NOTE/"
@@ -32,14 +31,20 @@ UNKNOWNN_CONFIG_FILE = "There is an unknown configuration file issue - " + CONFI
 MISSING_CONFIG_FILE = "The configuration file - " + CONFIG_FILE + " is missing. Please check the documention on recreating it"
 BADFILE_CONFIG_FILE = "Unable to create " + CONFIG_FILE + ". The file system issue such as locked or corrupted"
 
-ILLEGAL_FILE_CHARS = ['<', '>', ':', '"', '/', '\\', '|', '?', '*', '&', '\n', '\r', '\t']
-ILLEGAL_TAG_CHARS = ['~', '`', '!', '@', '$', '%', '^', '(', ')', '+', '=', '{', '}', '[', ']', '<', '>', ';', ':', ',', '.', '"', '/', '\\', '|', '?', '*', '&', '\n', '\r']
+ILLEGAL_FILE_CHARS = [
+    '<', '>', ':', '"', '/', '\\', '|', '?', '*', '&', '\n', '\r', '\t'
+]
+ILLEGAL_TAG_CHARS = [
+    '~', '`', '!', '@', '$', '%', '^', '(', ')', '+', '=', '{', '}', '[', ']',
+    '<', '>', ';', ':', ',', '.', '"', '/', '\\', '|', '?', '*', '&', '\n',
+    '\r'
+]
 
 default_settings = {
     'google_userid': USERID_EMPTY,
     'output_path': OUTPUTPATH,
     'media_path': MEDIADEFAULTPATH,
-    }
+}
 
 media_downloaded = False
 
@@ -48,11 +53,12 @@ keep_name_list = []
 
 
 class ConfigurationException(Exception):
+
     def __init__(self, msg):
         self.msg = msg
+
     def __str__(self):
         return self.msg
-
 
 
 def load_config():
@@ -79,16 +85,17 @@ def load_config():
     return configdict
 
 
-
 # Note that the use of temporary %%% is because notes can have the same URL repeated and replace would fail
 def url_to_md(text):
     # pylint: disable=anomalous-backslash-in-string
-    urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[~#$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', text)
+    urls = re.findall(
+        'http[s]?://(?:[a-zA-Z]|[0-9]|[~#$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+',
+        text)
     for url in urls:
-        text = text.replace(url, "[" + url[:1] + "%%%" +url[2:] + "]("+url[:1] + "%%%" +url[2:]+")", 1)
-    return(text.replace("h%%%tp", "http"))
-
-
+        text = text.replace(
+            url, "[" + url[:1] + "%%%" + url[2:] + "](" + url[:1] + "%%%" +
+            url[2:] + ")", 1)
+    return (text.replace("h%%%tp", "http"))
 
 
 def keep_init():
@@ -132,7 +139,6 @@ def keep_save_token(keeptoken, userid):
 
 def keep_download_blob(blob_url, blob_name, blob_path):
 
-
     try:
 
         dest_path = blob_path + "/" + blob_name
@@ -141,7 +147,7 @@ def keep_download_blob(blob_url, blob_name, blob_path):
         r = requests.get(blob_url)
         if r.status_code == 200:
 
-            with open(data_file,'wb') as f:
+            with open(data_file, 'wb') as f:
                 f.write(r.content)
 
             if imghdr.what(data_file) == 'png':
@@ -161,7 +167,6 @@ def keep_download_blob(blob_url, blob_name, blob_path):
                 media_name = blob_name + extension
                 blob_final_path = dest_path + extension
 
-
             shutil.copyfile(data_file, blob_final_path)
         else:
             media_name = data_file
@@ -172,9 +177,10 @@ def keep_download_blob(blob_url, blob_name, blob_path):
 
         media_name = media_name.replace(" ", "%20")
         mediapath = load_config().get("media_path").rstrip("/") + "/"
-        return("![" + mediapath + media_name + "](" + mediapath + media_name + ")")
+        return ("![" + mediapath + media_name + "](" + mediapath + media_name +
+                ")")
     except:
-        print ("Error in keep_download_blob()")
+        print("Error in keep_download_blob()")
         raise
 
 
@@ -182,7 +188,7 @@ def keep_note_name(note_title, note_date):
     if note_title in keep_name_list:
         note_title = note_title + note_date
         note_title = keep_note_name(note_title, note_date)
-    return(note_title)
+    return (note_title)
 
 
 def keep_md_exists(md_file, outpath, note_title, note_date):
@@ -192,21 +198,22 @@ def keep_md_exists(md_file, outpath, note_title, note_date):
         note_title = keep_note_name(note_title, note_date)
         keep_name_list.append(note_title)
         md_file = Path(outpath, note_title + ".md")
-    return(note_title)
+    return (note_title)
 
 
-def keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_existing):
+def keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite,
+                      skip_existing):
 
     try:
 
-        md_text = gnote.text.replace(u"\u2610", '- [ ]').replace(u"\u2611", ' - [x]')
+        md_text = gnote.text.replace(u"\u2610",
+                                     '- [ ]').replace(u"\u2611", ' - [x]')
 
         outpath = load_config().get("output_path").rstrip("/")
         mediapath = load_config().get("media_path").rstrip("/")
 
         if not os.path.exists(outpath):
             os.mkdir(outpath)
-
 
         mediapath = outpath + "/" + mediapath + "/"
         if not os.path.exists(mediapath):
@@ -219,9 +226,10 @@ def keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_ex
         if not overwrite:
             if md_file.exists():
                 if skip_existing:
-                    return(0)
+                    return (0)
                 else:
-                    gnote.title = keep_md_exists(md_file, outpath, gnote.title, note_date)
+                    gnote.title = keep_md_exists(md_file, outpath, gnote.title,
+                                                 note_date)
                     md_file = Path(outpath, gnote.title + ".md")
 
         for idx, blob in enumerate(gnote.blobs):
@@ -229,7 +237,8 @@ def keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_ex
                 image_url = keepapi.getMediaLink(blob)
             except AttributeError as e:
                 if "'NoneType' object has no attribute 'type'" in str(e):
-                    print (f"continuing, despite note {gnote.title} raising:" , repr(e) )
+                    print(f"continuing, despite note {gnote.title} raising:",
+                          repr(e))
                     continue
                 raise e
             #print (image_url)
@@ -237,29 +246,27 @@ def keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_ex
             blob_file = keep_download_blob(image_url, image_name, mediapath)
             md_text = blob_file + "\n" + md_text
 
+        print(gnote.title)
+        print(note_labels)
+        print(note_date + "\r\n")
 
-        print (gnote.title)
-        print (note_labels)
-        print (note_date + "\r\n")
-
-        f=open(md_file,"w+", encoding='utf-8', errors="ignore")
+        f = open(md_file, "w+", encoding='utf-8', errors="ignore")
         #f.write(url_to_md(url_to_md(note_text, "http://"), "https://") + "\n")
         f.write(url_to_md(md_text) + "\n")
         f.write("\n" + note_labels + "\n\n")
-        f.write("Created: " + str(gnote.timestamps.created) + "      Updated: " + str(gnote.timestamps.updated) + "\n\n")
-        f.write("["+ KEEP_NOTE_URL + str(gnote.id) + "](" + KEEP_NOTE_URL + str(gnote.id) + ")\n\n")
+        f.write("Created: " + str(gnote.timestamps.created) +
+                "      Updated: " + str(gnote.timestamps.updated) + "\n\n")
+        f.write("[" + KEEP_NOTE_URL + str(gnote.id) + "](" + KEEP_NOTE_URL +
+                str(gnote.id) + ")\n\n")
         f.close
-        return(1)
+        return (1)
     except Exception as e:
-        raise Exception("Problem with markdown file creation: " + str(md_file) + " -- " + TECH_ERR + repr(e))
+        raise Exception("Problem with markdown file creation: " +
+                        str(md_file) + " -- " + TECH_ERR + repr(e))
 
 
-
-def process_keep_gnotes(gnotes, overwrite, archive_only, preserve_labels,
-                        skip_existing, text_for_title):
-    pass
-
-def keep_query_convert(keepapi, keepquery, overwrite, archive_only, preserve_labels, skip_existing, text_for_title):
+def keep_query_convert(keepapi, keepquery, overwrite, archive_only,
+                       preserve_labels, skip_existing, text_for_title):
 
     try:
         count = 0
@@ -269,21 +276,32 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only, preserve_lab
             gnotes = keepapi.all()
         else:
             if keepquery[0] == "#":
-                gnotes = keepapi.find(labels=[keepapi.findLabel(keepquery[1:])], archived=archive_only, trashed=False)
+                gnotes = keepapi.find(
+                    labels=[keepapi.findLabel(keepquery[1:])],
+                    archived=archive_only,
+                    trashed=False)
             else:
-                gnotes = keepapi.find(query=keepquery, archived=archive_only, trashed=False)
+                gnotes = keepapi.find(query=keepquery,
+                                      archived=archive_only,
+                                      trashed=False)
 
         for gnote in gnotes:
-            note_date = re.sub('[^A-z0-9-]', ' ', str(gnote.timestamps.created).replace(":","").replace(".", "-"))
+            note_date = re.sub(
+                '[^A-z0-9-]', ' ',
+                str(gnote.timestamps.created).replace(":",
+                                                      "").replace(".", "-"))
 
             if gnote.title == '':
                 if text_for_title:
-                    gnote.title = re.sub('[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', '', gnote.text[0:50]) #.replace(' ',''))
+                    gnote.title = re.sub(
+                        '[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', '',
+                        gnote.text[0:50])  #.replace(' ',''))
                 else:
                     gnote.title = note_date
 
-
-            gnote.title = re.sub('[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', ' ', gnote.title[0:99]) #re.sub('[^A-z0-9-]', ' ', gnote.title)[0:99]
+            gnote.title = re.sub(
+                '[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', ' ', gnote.
+                title[0:99])  #re.sub('[^A-z0-9-]', ' ', gnote.title)[0:99]
             #note_text = gnote.text #gnote.text.replace('”','"').replace('“','"').replace("‘","'").replace("’","'").replace('•', "-").replace(u"\u2610", '[ ]').replace(u"\u2611", '[x]').replace(u'\xa0', u' ').replace(u'\u2013', '--').replace(u'\u2014', '--').replace(u'\u2026', '...').replace(u'\u00b1', '+/-')
 
             note_label_list = gnote.labels
@@ -294,18 +312,24 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only, preserve_lab
                     note_labels = note_labels + " #" + str(label)
             else:
                 for label in labels:
-                    note_labels = note_labels + " #" + str(label).replace(' ','-').replace('&','and')
-                note_labels = re.sub('[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-', note_labels) #re.sub('[^A-z0-9-_# ]', '-', note_labels)
-
+                    note_labels = note_labels + " #" + str(label).replace(
+                        ' ', '-').replace('&', 'and')
+                note_labels = re.sub(
+                    '[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-',
+                    note_labels)  #re.sub('[^A-z0-9-_# ]', '-', note_labels)
 
             if archive_only:
                 if gnote.archived and gnote.trashed == False:
-                    ccnt = keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_existing)
+                    ccnt = keep_save_md_file(keepapi, gnote, note_labels,
+                                             note_date, overwrite,
+                                             skip_existing)
                 else:
                     ccnt = 0
             else:
                 if gnote.archived == False and gnote.trashed == False:
-                    ccnt = keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_existing)
+                    ccnt = keep_save_md_file(keepapi, gnote, note_labels,
+                                             note_date, overwrite,
+                                             skip_existing)
 
             count = count + ccnt
 
@@ -315,12 +339,12 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only, preserve_lab
 
         return (count)
     except:
-        print ("Error in keep_query_convert()")
+        print("Error in keep_query_convert()")
         raise
 
 
-
 #--------------------- UI / CLI ------------------------------
+
 
 def ui_login(keepapi, defaults, keyring_reset, master_token):
 
@@ -329,12 +353,14 @@ def ui_login(keepapi, defaults, keyring_reset, master_token):
         userid = defaults.get("google_userid").strip().lower()
 
         if userid == USERID_EMPTY:
-            userid = click.prompt('Enter your Google account username', type=str)
+            userid = click.prompt('Enter your Google account username',
+                                  type=str)
         else:
-            print("Your Google account name in the " + CONFIG_FILE + " file is: " + userid + " -- Welcome!")
+            print("Your Google account name in the " + CONFIG_FILE +
+                  " file is: " + userid + " -- Welcome!")
 
         if keyring_reset:
-            print ("Clearing keyring")
+            print("Clearing keyring")
             keep_clear_keyring(keepapi, userid)
 
         if master_token:
@@ -343,48 +369,59 @@ def ui_login(keepapi, defaults, keyring_reset, master_token):
         else:
             ktoken = keep_token(keepapi, userid)
         if ktoken == None:
-            pw = getpass.getpass(prompt='Enter your Google Password: ', stream=None)
-            print ("\r\n\r\nOne moment...")
+            pw = getpass.getpass(prompt='Enter your Google Password: ',
+                                 stream=None)
+            print("\r\n\r\nOne moment...")
 
             ktoken = keep_login(keepapi, userid, pw, keyring_reset)
             if ktoken:
                 if keyring_reset:
-                    print ("You've succesfully logged into Google Keep!")
+                    print("You've succesfully logged into Google Keep!")
                 else:
-                    print ("You've succesfully logged into Google Keep! Your Keep access token has been securely stored in this computer's keyring.")
+                    print(
+                        "You've succesfully logged into Google Keep! Your Keep access token has been securely stored in this computer's keyring."
+                    )
             #else:
             #  print ("Invalid Google userid or pw! Please try again.")
 
         else:
-            print ("You've succesfully logged into Google Keep using local keyring access token!")
+            print(
+                "You've succesfully logged into Google Keep using local keyring access token!"
+            )
 
         keep_resume(keepapi, ktoken, userid)
         return (ktoken)
 
     except Exception as e:
-        print ("\r\nUsername or password is incorrect (" + repr(e) + ")")
+        print("\r\nUsername or password is incorrect (" + repr(e) + ")")
         raise
 
 
-
-def ui_query(keepapi, search_term, overwrite, archive_only, preserve_labels, skip_existing, text_for_title):
+def ui_query(keepapi, search_term, overwrite, archive_only, preserve_labels,
+             skip_existing, text_for_title):
 
     try:
         if search_term != None:
-            count = keep_query_convert(keepapi, search_term, overwrite, archive_only, preserve_labels, skip_existing, text_for_title)
-            print ("\nTotal converted notes: " + str(count))
+            count = keep_query_convert(keepapi, search_term, overwrite,
+                                       archive_only, preserve_labels,
+                                       skip_existing, text_for_title)
+            print("\nTotal converted notes: " + str(count))
             return
         else:
             kquery = "kquery"
             while kquery:
-                kquery = click.prompt("\r\nEnter a keyword search, label search or '--all' to convert Keep notes to md or '--x' to exit", type=str)
+                kquery = click.prompt(
+                    "\r\nEnter a keyword search, label search or '--all' to convert Keep notes to md or '--x' to exit",
+                    type=str)
                 if kquery != "--x":
-                    count = keep_query_convert(keepapi, kquery, overwrite, archive_only, preserve_labels, skip_existing, text_for_title)
-                    print ("\nTotal converted notes: " + str(count))
+                    count = keep_query_convert(keepapi, kquery, overwrite,
+                                               archive_only, preserve_labels,
+                                               skip_existing, text_for_title)
+                    print("\nTotal converted notes: " + str(count))
                 else:
                     return
     except Exception as e:
-        print ("Conversion to markdown error - " + repr(e) + " ")
+        print("Conversion to markdown error - " + repr(e) + " ")
         raise
 
 
@@ -392,36 +429,57 @@ def ui_welcome_config():
     try:
         defaults = load_config()
         mp = defaults.get("media_path")
-        if ( (":" in mp) or (mp[0] == '/') ):
-            raise ValueError("Media path: '" + mp + "' within your config file - " + CONFIG_FILE + " - must be relative to the output path and cannot start with / or a drive-mount")
+        if ((":" in mp) or (mp[0] == '/')):
+            raise ValueError(
+                "Media path: '" + mp + "' within your config file - " +
+                CONFIG_FILE +
+                " - must be relative to the output path and cannot start with / or a drive-mount"
+            )
         return defaults
     except Exception as e:
-        print ("\r\nConfiguration file error - " + CONFIG_FILE + " - " + repr(e) + " ")
+        print("\r\nConfiguration file error - " + CONFIG_FILE + " - " +
+              repr(e) + " ")
         raise
 
 
-
-
 @click.command()
-@click.option('-r', is_flag=True, help="Will reset and not use the local keep access token in your system's keyring")
-@click.option('-o', is_flag=True, help="Overwrite any existing markdown files with the same name")
+@click.option(
+    '-r',
+    is_flag=True,
+    help=
+    "Will reset and not use the local keep access token in your system's keyring"
+)
+@click.option('-o',
+              is_flag=True,
+              help="Overwrite any existing markdown files with the same name")
 @click.option('-a', is_flag=True, help="Search and export only archived notes")
-@click.option('-p', is_flag=True, help="Preserve keep labels with spaces and special characters")
-@click.option('-s', is_flag=True, help="Skip over any existing notes with the same title")
-@click.option('-c', is_flag=True, help="Use starting content within note body instead of create date for md filename")
-@click.option('-b', '--search-term', help="Run in batch mode with a specific Keep search term")
+@click.option('-p',
+              is_flag=True,
+              help="Preserve keep labels with spaces and special characters")
+@click.option('-s',
+              is_flag=True,
+              help="Skip over any existing notes with the same title")
+@click.option(
+    '-c',
+    is_flag=True,
+    help=
+    "Use starting content within note body instead of create date for md filename"
+)
+@click.option('-b',
+              '--search-term',
+              help="Run in batch mode with a specific Keep search term")
 @click.option('-t', '--master-token', help="Log in using master keep token")
 def main(r, o, a, p, s, c, search_term, master_token):
-
 
     try:
 
         click.echo("\r\nWelcome to Keep it Markdown or KIM!\r\n")
 
         if o and s:
-            print ("Overwrite and Skip flags are not compatible together -- please use one or the other...")
+            print(
+                "Overwrite and Skip flags are not compatible together -- please use one or the other..."
+            )
             exit()
-
 
         kapi = keep_init()
 
@@ -429,14 +487,12 @@ def main(r, o, a, p, s, c, search_term, master_token):
 
         ui_query(kapi, search_term, o, a, p, s, c)
 
-
     except:
-        print ("Could not excute KIM")
-
+        print("Could not excute KIM")
 
 
 #Version 0.4.3
 
 if __name__ == '__main__':
 
-    main() # pylint: disable=no-value-for-parameter
+    main()  # pylint: disable=no-value-for-parameter

--- a/kim.py
+++ b/kim.py
@@ -33,14 +33,8 @@ UNKNOWNN_CONFIG_FILE = "There is an unknown configuration file issue - " + CONFI
 MISSING_CONFIG_FILE = "The configuration file - " + CONFIG_FILE + " is missing. Please check the documention on recreating it"
 BADFILE_CONFIG_FILE = "Unable to create " + CONFIG_FILE + ". The file system issue such as locked or corrupted"
 
-ILLEGAL_FILE_CHARS = [
-    '<', '>', ':', '"', '/', '\\', '|', '?', '*', '&', '\n', '\r', '\t'
-]
-ILLEGAL_TAG_CHARS = [
-    '~', '`', '!', '@', '$', '%', '^', '(', ')', '+', '=', '{', '}', '[', ']',
-    '<', '>', ';', ':', ',', '.', '"', '/', '\\', '|', '?', '*', '&', '\n',
-    '\r'
-]
+ILLEGAL_FILE_CHARS = ['<', '>', ':', '"', '/', '\\', '|', '?', '*', '&', '\n', '\r', '\t']
+ILLEGAL_TAG_CHARS = ['~', '`', '!', '@', '$', '%', '^', '(', ')', '+', '=', '{', '}', '[', ']', '<', '>', ';', ':', ',', '.', '"', '/', '\\', '|', '?', '*', '&', '\n', '\r']
 
 default_settings = {
     'google_userid': USERID_EMPTY,
@@ -90,13 +84,9 @@ def load_config():
 # Note that the use of temporary %%% is because notes can have the same URL repeated and replace would fail
 def url_to_md(text):
     # pylint: disable=anomalous-backslash-in-string
-    urls = re.findall(
-        'http[s]?://(?:[a-zA-Z]|[0-9]|[~#$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+',
-        text)
+    urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[~#$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', text)
     for url in urls:
-        text = text.replace(
-            url, "[" + url[:1] + "%%%" + url[2:] + "](" + url[:1] + "%%%" +
-            url[2:] + ")", 1)
+        text = text.replace(url, "[" + url[:1] + "%%%" + url[2:] + "](" + url[:1] + "%%%" + url[2:] + ")", 1)
     return (text.replace("h%%%tp", "http"))
 
 
@@ -179,8 +169,7 @@ def keep_download_blob(blob_url, blob_name, blob_path):
 
         media_name = media_name.replace(" ", "%20")
         mediapath = load_config().get("media_path").rstrip("/") + "/"
-        return ("![" + mediapath + media_name + "](" + mediapath + media_name +
-                ")")
+        return ("![" + mediapath + media_name + "](" + mediapath + media_name + ")")
     except:
         print("Error in keep_download_blob()")
         raise
@@ -223,8 +212,7 @@ def keep_save_md_file(gnote, overwrite, skip_existing):
                 if skip_existing:
                     return (0)
                 else:
-                    gnote.title = keep_md_exists(md_file, outpath, gnote.title,
-                                                 note_date)
+                    gnote.title = keep_md_exists(md_file, outpath, gnote.title, note_date)
                     md_file = Path(outpath, gnote.title + ".md")
 
         lines = md_text.split("\n")
@@ -250,13 +238,11 @@ created: ["{str(gnote.timestamps.created)}"]
         f.write(url_to_md(md_text) + "\n")
         f.write("\n" + note_labels + "\n")
         if gnote.id != "unknown":
-            f.write("[" + KEEP_NOTE_URL + str(gnote.id) + "](" +
-                    KEEP_NOTE_URL + str(gnote.id) + ")\n\n")
+            f.write("[" + KEEP_NOTE_URL + str(gnote.id) + "](" + KEEP_NOTE_URL + str(gnote.id) + ")\n\n")
         f.close
         return (1)
     except Exception as e:
-        raise Exception("Problem with markdown file creation: " +
-                        str(md_file) + " -- " + TECH_ERR + repr(e))
+        raise Exception("Problem with markdown file creation: " + str(md_file) + " -- " + TECH_ERR + repr(e))
 
 
 def setup_folders():
@@ -281,11 +267,8 @@ class Gnote:
     timestamps = Timestamps()
 
 
-def keep_takeout_load(takeout_folder, overwrite, archive_only, preserve_labels,
-                      skip_existing):
-    files = [
-        file for file in os.listdir(takeout_folder) if file.endswith(".json")
-    ]
+def keep_takeout_load(takeout_folder, overwrite, archive_only, preserve_labels, skip_existing):
+    files = [file for file in os.listdir(takeout_folder) if file.endswith(".json")]
     gnotes = []
     count = 0
 
@@ -314,16 +297,11 @@ def keep_takeout_load(takeout_folder, overwrite, archive_only, preserve_labels,
                 note_labels = note_labels + " #" + str(label["name"])
         else:
             for label in data["labels"]:
-                note_labels = note_labels + " #" + str(label["name"]).replace(
-                    ' ', '-').replace('&', 'and')
-            note_labels = re.sub(
-                '[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-',
-                note_labels)  #re.sub('[^A-z0-9-_# ]', '-', note_labels)
+                note_labels = note_labels + " #" + str(label["name"]).replace(' ', '-').replace('&', 'and')
+            note_labels = re.sub('[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-', note_labels)  #re.sub('[^A-z0-9-_# ]', '-', note_labels)
 
-        created_at = datetime.fromtimestamp(data["createdTimestampUsec"] /
-                                            1000000)
-        updated_at = datetime.fromtimestamp(data["userEditedTimestampUsec"] /
-                                            1000000)
+        created_at = datetime.fromtimestamp(data["createdTimestampUsec"] / 1000000)
+        updated_at = datetime.fromtimestamp(data["userEditedTimestampUsec"] / 1000000)
         gnote.timestamps.created = created_at
         gnote.timestamps.updated = updated_at
         setattr(gnote, 'note_date', str(updated_at)[:19].replace(" ", "T"))
@@ -342,8 +320,7 @@ def keep_takeout_load(takeout_folder, overwrite, archive_only, preserve_labels,
     return (gnotes, len(gnotes))
 
 
-def keep_query_convert(keepapi, keepquery, overwrite, archive_only,
-                       preserve_labels, skip_existing, text_for_title):
+def keep_query_convert(keepapi, keepquery, overwrite, archive_only, preserve_labels, skip_existing, text_for_title):
 
     try:
         count = 0
@@ -353,55 +330,39 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only,
             gnotes = keepapi.all()
         else:
             if keepquery[0] == "#":
-                gnotes = keepapi.find(
-                    labels=[keepapi.findLabel(keepquery[1:])],
-                    archived=archive_only,
-                    trashed=False)
+                gnotes = keepapi.find(labels=[keepapi.findLabel(keepquery[1:])], archived=archive_only, trashed=False)
             else:
-                gnotes = keepapi.find(query=keepquery,
-                                      archived=archive_only,
-                                      trashed=False)
+                gnotes = keepapi.find(query=keepquery, archived=archive_only, trashed=False)
 
         for gnote in gnotes:
 
-            md_text = gnote.text.replace(u"\u2610",
-                                         '- [ ]').replace(u"\u2611", ' - [x]')
+            md_text = gnote.text.replace(u"\u2610", '- [ ]').replace(u"\u2611", ' - [x]')
             for idx, blob in enumerate(gnote.blobs):
                 try:
                     image_url = keepapi.getMediaLink(blob)
                 except AttributeError as e:
                     if "'NoneType' object has no attribute 'type'" in str(e):
-                        print(
-                            f"continuing, despite note {gnote.title} raising:",
-                            repr(e))
+                        print(f"continuing, despite note {gnote.title} raising:", repr(e))
                         continue
                     raise e
                 #print (image_url)
                 image_name = gnote.title + str(idx)
-                blob_file = keep_download_blob(image_url, image_name,
-                                               mediapath)
+                blob_file = keep_download_blob(image_url, image_name, mediapath)
                 md_text = blob_file + "\n" + md_text
                 setattr(gnote, 'image_name', image_name)
                 setattr(gnote, 'blob_file', blob_file)
 
             setattr(gnote, 'md_text', md_text)
 
-            note_date = re.sub(
-                '[^A-z0-9-]', ' ',
-                str(gnote.timestamps.created).replace(":",
-                                                      "").replace(".", "-"))
+            note_date = re.sub('[^A-z0-9-]', ' ', str(gnote.timestamps.created).replace(":", "").replace(".", "-"))
 
             if gnote.title == '':
                 if text_for_title:
-                    gnote.title = re.sub(
-                        '[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', '',
-                        gnote.text[0:50])  #.replace(' ',''))
+                    gnote.title = re.sub('[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', '', gnote.text[0:50])  #.replace(' ',''))
                 else:
                     gnote.title = note_date
 
-            gnote.title = re.sub(
-                '[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', ' ', gnote.
-                title[0:99])  #re.sub('[^A-z0-9-]', ' ', gnote.title)[0:99]
+            gnote.title = re.sub('[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', ' ', gnote.title[0:99])  #re.sub('[^A-z0-9-]', ' ', gnote.title)[0:99]
             #note_text = gnote.text #gnote.text.replace('”','"').replace('“','"').replace("‘","'").replace("’","'").replace('•', "-").replace(u"\u2610", '[ ]').replace(u"\u2611", '[x]').replace(u'\xa0', u' ').replace(u'\u2013', '--').replace(u'\u2014', '--').replace(u'\u2026', '...').replace(u'\u00b1', '+/-')
 
             note_label_list = gnote.labels
@@ -412,11 +373,8 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only,
                     note_labels = note_labels + " #" + str(label)
             else:
                 for label in labels:
-                    note_labels = note_labels + " #" + str(label).replace(
-                        ' ', '-').replace('&', 'and')
-                note_labels = re.sub(
-                    '[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-',
-                    note_labels)  #re.sub('[^A-z0-9-_# ]', '-', note_labels)
+                    note_labels = note_labels + " #" + str(label).replace(' ', '-').replace('&', 'and')
+                note_labels = re.sub('[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-', note_labels)  #re.sub('[^A-z0-9-_# ]', '-', note_labels)
 
             setattr(gnote, 'note_date', note_date)
             setattr(gnote, 'note_labels', note_labels)
@@ -455,11 +413,9 @@ def ui_login(keepapi, defaults, keyring_reset, master_token):
         userid = defaults.get("google_userid").strip().lower()
 
         if userid == USERID_EMPTY:
-            userid = click.prompt('Enter your Google account username',
-                                  type=str)
+            userid = click.prompt('Enter your Google account username', type=str)
         else:
-            print("Your Google account name in the " + CONFIG_FILE +
-                  " file is: " + userid + " -- Welcome!")
+            print("Your Google account name in the " + CONFIG_FILE + " file is: " + userid + " -- Welcome!")
 
         if keyring_reset:
             print("Clearing keyring")
@@ -471,8 +427,7 @@ def ui_login(keepapi, defaults, keyring_reset, master_token):
         else:
             ktoken = keep_token(keepapi, userid)
         if ktoken == None:
-            pw = getpass.getpass(prompt='Enter your Google Password: ',
-                                 stream=None)
+            pw = getpass.getpass(prompt='Enter your Google Password: ', stream=None)
             print("\r\n\r\nOne moment...")
 
             ktoken = keep_login(keepapi, userid, pw, keyring_reset)
@@ -480,16 +435,12 @@ def ui_login(keepapi, defaults, keyring_reset, master_token):
                 if keyring_reset:
                     print("You've succesfully logged into Google Keep!")
                 else:
-                    print(
-                        "You've succesfully logged into Google Keep! Your Keep access token has been securely stored in this computer's keyring."
-                    )
+                    print("You've succesfully logged into Google Keep! Your Keep access token has been securely stored in this computer's keyring.")
             #else:
             #  print ("Invalid Google userid or pw! Please try again.")
 
         else:
-            print(
-                "You've succesfully logged into Google Keep using local keyring access token!"
-            )
+            print("You've succesfully logged into Google Keep using local keyring access token!")
 
         keep_resume(keepapi, ktoken, userid)
         return (ktoken)
@@ -499,25 +450,19 @@ def ui_login(keepapi, defaults, keyring_reset, master_token):
         raise
 
 
-def ui_query(keepapi, takeout_folder, search_term, overwrite, archive_only,
-             preserve_labels, skip_existing, text_for_title):
+def ui_query(keepapi, takeout_folder, search_term, overwrite, archive_only, preserve_labels, skip_existing, text_for_title):
 
     try:
         setup_folders()
         if takeout_folder:
-            (gnotes, count) = keep_takeout_load(takeout_folder, overwrite,
-                                                archive_only, preserve_labels,
-                                                skip_existing)
+            (gnotes, count) = keep_takeout_load(takeout_folder, overwrite, archive_only, preserve_labels, skip_existing)
             for gnote in gnotes:
                 if gnote.export:
                     keep_save_md_file(gnote, overwrite, skip_existing)
             print("\nTotal converted notes: " + str(count))
             return
         elif search_term != None:
-            (gnotes, count) = keep_query_convert(keepapi, search_term,
-                                                 overwrite, archive_only,
-                                                 preserve_labels,
-                                                 skip_existing, text_for_title)
+            (gnotes, count) = keep_query_convert(keepapi, search_term, overwrite, archive_only, preserve_labels, skip_existing, text_for_title)
             for gnote in gnotes:
                 if gnote.export:
                     keep_save_md_file(gnote, overwrite, skip_existing)
@@ -526,14 +471,9 @@ def ui_query(keepapi, takeout_folder, search_term, overwrite, archive_only,
         else:
             kquery = "kquery"
             while kquery:
-                kquery = click.prompt(
-                    "\r\nEnter a keyword search, label search or '--all' to convert Keep notes to md or '--x' to exit",
-                    type=str)
+                kquery = click.prompt("\r\nEnter a keyword search, label search or '--all' to convert Keep notes to md or '--x' to exit", type=str)
                 if kquery != "--x":
-                    (gnotes,
-                     count) = keep_query_convert(keepapi, kquery, overwrite,
-                                                 archive_only, preserve_labels,
-                                                 skip_existing, text_for_title)
+                    (gnotes, count) = keep_query_convert(keepapi, kquery, overwrite, archive_only, preserve_labels, skip_existing, text_for_title)
                     for gnote in gnotes:
                         if gnote.export:
                             keep_save_md_file(gnote, overwrite, skip_existing)
@@ -551,47 +491,23 @@ def ui_welcome_config():
         defaults = load_config()
         mp = defaults.get("media_path")
         if ((":" in mp) or (mp[0] == '/')):
-            raise ValueError(
-                "Media path: '" + mp + "' within your config file - " +
-                CONFIG_FILE +
-                " - must be relative to the output path and cannot start with / or a drive-mount"
-            )
+            raise ValueError("Media path: '" + mp + "' within your config file - " + CONFIG_FILE +
+                             " - must be relative to the output path and cannot start with / or a drive-mount")
         return defaults
     except Exception as e:
-        print("\r\nConfiguration file error - " + CONFIG_FILE + " - " +
-              repr(e) + " ")
+        print("\r\nConfiguration file error - " + CONFIG_FILE + " - " + repr(e) + " ")
         raise
 
 
 @click.command()
-@click.option(
-    '-r',
-    is_flag=True,
-    help=
-    "Will reset and not use the local keep access token in your system's keyring"
-)
-@click.option('-o',
-              is_flag=True,
-              help="Overwrite any existing markdown files with the same name")
+@click.option('-r', is_flag=True, help="Will reset and not use the local keep access token in your system's keyring")
+@click.option('-o', is_flag=True, help="Overwrite any existing markdown files with the same name")
 @click.option('-a', is_flag=True, help="Search and export only archived notes")
-@click.option('-p',
-              is_flag=True,
-              help="Preserve keep labels with spaces and special characters")
-@click.option('-s',
-              is_flag=True,
-              help="Skip over any existing notes with the same title")
-@click.option(
-    '-c',
-    is_flag=True,
-    help=
-    "Use starting content within note body instead of create date for md filename"
-)
-@click.option('-b',
-              '--search-term',
-              help="Run in batch mode with a specific Keep search term")
-@click.option('-f',
-              '--takeout-folder',
-              help="Run in batch mode with a specific Keep search term")
+@click.option('-p', is_flag=True, help="Preserve keep labels with spaces and special characters")
+@click.option('-s', is_flag=True, help="Skip over any existing notes with the same title")
+@click.option('-c', is_flag=True, help="Use starting content within note body instead of create date for md filename")
+@click.option('-b', '--search-term', help="Run in batch mode with a specific Keep search term")
+@click.option('-f', '--takeout-folder', help="Run in batch mode with a specific Keep search term")
 @click.option('-t', '--master-token', help="Log in using master keep token")
 def main(r, o, a, p, s, c, search_term, takeout_folder, master_token):
 
@@ -600,9 +516,7 @@ def main(r, o, a, p, s, c, search_term, takeout_folder, master_token):
         click.echo("\r\nWelcome to Keep it Markdown or KIM!\r\n")
 
         if o and s:
-            print(
-                "Overwrite and Skip flags are not compatible together -- please use one or the other..."
-            )
+            print("Overwrite and Skip flags are not compatible together -- please use one or the other...")
             exit()
 
         kapi = keep_init()

--- a/kim.py
+++ b/kim.py
@@ -34,7 +34,7 @@ BADFILE_CONFIG_FILE = "Unable to create " + CONFIG_FILE + ". The file system iss
 
 ILLEGAL_FILE_CHARS = ['<', '>', ':', '"', '/', '\\', '|', '?', '*', '&', '\n', '\r', '\t']
 ILLEGAL_TAG_CHARS = ['~', '`', '!', '@', '$', '%', '^', '(', ')', '+', '=', '{', '}', '[', ']', '<', '>', ';', ':', ',', '.', '"', '/', '\\', '|', '?', '*', '&', '\n', '\r']
- 
+
 default_settings = {
     'google_userid': USERID_EMPTY,
     'output_path': OUTPUTPATH,
@@ -57,14 +57,14 @@ class ConfigurationException(Exception):
 
 def load_config():
     config = configparser.ConfigParser()
-  
+
     try:
         cfile = config.read(CONFIG_FILE)
     except configparser.MissingSectionHeaderError:
         raise ConfigurationException(MALFORMED_CONFIG_FILE)
     except Exception:
         raise ConfigurationException(UNKNOWNN_CONFIG_FILE)
-    
+
     configdict = {}
     if not cfile:
         config[DEFAULT_SECTION] = default_settings
@@ -76,20 +76,20 @@ def load_config():
     options = config.options(DEFAULT_SECTION)
     for option in options:
         configdict[option] = config.get(DEFAULT_SECTION, option)
-    return configdict 
+    return configdict
 
 
 
 # Note that the use of temporary %%% is because notes can have the same URL repeated and replace would fail
 def url_to_md(text):
     # pylint: disable=anomalous-backslash-in-string
-    urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[~#$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', text) 
+    urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[~#$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', text)
     for url in urls:
-      text = text.replace(url, "[" + url[:1] + "%%%" +url[2:] + "]("+url[:1] + "%%%" +url[2:]+")", 1)
+        text = text.replace(url, "[" + url[:1] + "%%%" +url[2:] + "]("+url[:1] + "%%%" +url[2:]+")", 1)
     return(text.replace("h%%%tp", "http"))
 
 
-    
+
 
 def keep_init():
     keepapi = gkeepapi.Keep()
@@ -103,23 +103,23 @@ def keep_token(keepapi, userid):
 
 def keep_clear_keyring(keepapi, userid):
     try:
-      keyring.delete_password(KEEP_KEYRING_ID, userid)
+        keyring.delete_password(KEEP_KEYRING_ID, userid)
     except:
-      return None
+        return None
     else:
-      return True
+        return True
 
 
 def keep_login(keepapi, userid, pw, keyring_reset):
     try:
-      keepapi.login(userid, pw)
+        keepapi.login(userid, pw)
     except:
-      return None
+        return None
     else:
-      keep_token = keepapi.getMasterToken()
-      if keyring_reset == False:
-        keyring.set_password(KEEP_KEYRING_ID, userid, keep_token)
-      return keep_token
+        keep_token = keepapi.getMasterToken()
+        if keyring_reset == False:
+            keyring.set_password(KEEP_KEYRING_ID, userid, keep_token)
+        return keep_token
 
 
 def keep_resume(keepapi, keeptoken, userid):
@@ -133,55 +133,55 @@ def keep_save_token(keeptoken, userid):
 def keep_download_blob(blob_url, blob_name, blob_path):
 
 
-  try:
+    try:
 
-    dest_path = blob_path + "/" + blob_name 
-    data_file = blob_name + ".dat"
+        dest_path = blob_path + "/" + blob_name
+        data_file = blob_name + ".dat"
 
-    r = requests.get(blob_url)
-    if r.status_code == 200:
+        r = requests.get(blob_url)
+        if r.status_code == 200:
 
-      with open(data_file,'wb') as f:
-        f.write(r.content)
+            with open(data_file,'wb') as f:
+                f.write(r.content)
 
-      if imghdr.what(data_file) == 'png':
-        media_name = blob_name + ".png"
-        blob_final_path = dest_path + ".png"
-      elif imghdr.what(data_file) == 'jpeg':
-        media_name = blob_name + ".jpg"
-        blob_final_path = dest_path + ".jpg"
-      elif imghdr.what(data_file) == 'gif':
-        media_name = blob_name + ".gif"
-        blob_final_path = dest_path + ".gif"
-      elif imghdr.what(data_file) == 'webp':
-        media_name = blob_name + ".webp"
-        blob_final_path = dest_path + ".webp"
-      else:
-        extension = ".aac"
-        media_name = blob_name + extension
-        blob_final_path = dest_path + extension
+            if imghdr.what(data_file) == 'png':
+                media_name = blob_name + ".png"
+                blob_final_path = dest_path + ".png"
+            elif imghdr.what(data_file) == 'jpeg':
+                media_name = blob_name + ".jpg"
+                blob_final_path = dest_path + ".jpg"
+            elif imghdr.what(data_file) == 'gif':
+                media_name = blob_name + ".gif"
+                blob_final_path = dest_path + ".gif"
+            elif imghdr.what(data_file) == 'webp':
+                media_name = blob_name + ".webp"
+                blob_final_path = dest_path + ".webp"
+            else:
+                extension = ".aac"
+                media_name = blob_name + extension
+                blob_final_path = dest_path + extension
 
 
-      shutil.copyfile(data_file, blob_final_path)
-    else:
-      media_name = data_file
-      blob_final_path = "Media could not be retrieved"
+            shutil.copyfile(data_file, blob_final_path)
+        else:
+            media_name = data_file
+            blob_final_path = "Media could not be retrieved"
 
-    if os.path.exists(data_file):
-      os.remove(data_file)
+        if os.path.exists(data_file):
+            os.remove(data_file)
 
-    media_name = media_name.replace(" ", "%20")
-    mediapath = load_config().get("media_path").rstrip("/") + "/"
-    return("![" + mediapath + media_name + "](" + mediapath + media_name + ")")
-  except:
-    print ("Error in keep_download_blob()")
-    raise
- 
+        media_name = media_name.replace(" ", "%20")
+        mediapath = load_config().get("media_path").rstrip("/") + "/"
+        return("![" + mediapath + media_name + "](" + mediapath + media_name + ")")
+    except:
+        print ("Error in keep_download_blob()")
+        raise
+
 
 def keep_note_name(note_title, note_date):
     if note_title in keep_name_list:
-      note_title = note_title + note_date
-      note_title = keep_note_name(note_title, note_date)
+        note_title = note_title + note_date
+        note_title = keep_note_name(note_title, note_date)
     return(note_title)
 
 
@@ -189,131 +189,135 @@ def keep_md_exists(md_file, outpath, note_title, note_date):
     #md_file = Path(outpath, note_title + ".md")
     keep_name_list.remove(note_title)
     while md_file.exists():
-      note_title = keep_note_name(note_title, note_date)
-      keep_name_list.append(note_title)
-      md_file = Path(outpath, note_title + ".md")
+        note_title = keep_note_name(note_title, note_date)
+        keep_name_list.append(note_title)
+        md_file = Path(outpath, note_title + ".md")
     return(note_title)
 
 
 def keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_existing):
 
     try:
-   
-      md_text = gnote.text.replace(u"\u2610", '- [ ]').replace(u"\u2611", ' - [x]')
 
-      outpath = load_config().get("output_path").rstrip("/")
-      mediapath = load_config().get("media_path").rstrip("/")
+        md_text = gnote.text.replace(u"\u2610", '- [ ]').replace(u"\u2611", ' - [x]')
 
-      if not os.path.exists(outpath):
-        os.mkdir(outpath)
+        outpath = load_config().get("output_path").rstrip("/")
+        mediapath = load_config().get("media_path").rstrip("/")
 
-     
-      mediapath = outpath + "/" + mediapath + "/"
-      if not os.path.exists(mediapath):
-          os.mkdir(mediapath)
+        if not os.path.exists(outpath):
+            os.mkdir(outpath)
 
-      gnote.title = keep_note_name(gnote.title, note_date)
-      keep_name_list.append(gnote.title)
 
-      md_file = Path(outpath, gnote.title + ".md")
-      if not overwrite:
-          if md_file.exists():
-            if skip_existing:
-              return(0)
-            else:
-              gnote.title = keep_md_exists(md_file, outpath, gnote.title, note_date)
-              md_file = Path(outpath, gnote.title + ".md")
+        mediapath = outpath + "/" + mediapath + "/"
+        if not os.path.exists(mediapath):
+            os.mkdir(mediapath)
 
-      for idx, blob in enumerate(gnote.blobs):
-        try:
-            image_url = keepapi.getMediaLink(blob)
-        except AttributeError as e:
-            if "'NoneType' object has no attribute 'type'" in str(e):
-                print (f"continuing, despite note {gnote.title} raising:" , repr(e) )
-                continue
-            raise e
-        #print (image_url)
-        image_name = gnote.title + str(idx)
-        blob_file = keep_download_blob(image_url, image_name, mediapath)
-        md_text = blob_file + "\n" + md_text 
- 
+        gnote.title = keep_note_name(gnote.title, note_date)
+        keep_name_list.append(gnote.title)
 
-      print (gnote.title)
-      print (note_labels)
-      print (note_date + "\r\n")
-  
-      f=open(md_file,"w+", encoding='utf-8', errors="ignore")
-      #f.write(url_to_md(url_to_md(note_text, "http://"), "https://") + "\n")
-      f.write(url_to_md(md_text) + "\n")
-      f.write("\n" + note_labels + "\n\n")
-      f.write("Created: " + str(gnote.timestamps.created) + "      Updated: " + str(gnote.timestamps.updated) + "\n\n")
-      f.write("["+ KEEP_NOTE_URL + str(gnote.id) + "](" + KEEP_NOTE_URL + str(gnote.id) + ")\n\n")
-      f.close
-      return(1)
+        md_file = Path(outpath, gnote.title + ".md")
+        if not overwrite:
+            if md_file.exists():
+                if skip_existing:
+                    return(0)
+                else:
+                    gnote.title = keep_md_exists(md_file, outpath, gnote.title, note_date)
+                    md_file = Path(outpath, gnote.title + ".md")
+
+        for idx, blob in enumerate(gnote.blobs):
+            try:
+                image_url = keepapi.getMediaLink(blob)
+            except AttributeError as e:
+                if "'NoneType' object has no attribute 'type'" in str(e):
+                    print (f"continuing, despite note {gnote.title} raising:" , repr(e) )
+                    continue
+                raise e
+            #print (image_url)
+            image_name = gnote.title + str(idx)
+            blob_file = keep_download_blob(image_url, image_name, mediapath)
+            md_text = blob_file + "\n" + md_text
+
+
+        print (gnote.title)
+        print (note_labels)
+        print (note_date + "\r\n")
+
+        f=open(md_file,"w+", encoding='utf-8', errors="ignore")
+        #f.write(url_to_md(url_to_md(note_text, "http://"), "https://") + "\n")
+        f.write(url_to_md(md_text) + "\n")
+        f.write("\n" + note_labels + "\n\n")
+        f.write("Created: " + str(gnote.timestamps.created) + "      Updated: " + str(gnote.timestamps.updated) + "\n\n")
+        f.write("["+ KEEP_NOTE_URL + str(gnote.id) + "](" + KEEP_NOTE_URL + str(gnote.id) + ")\n\n")
+        f.close
+        return(1)
     except Exception as e:
-      raise Exception("Problem with markdown file creation: " + str(md_file) + " -- " + TECH_ERR + repr(e))
+        raise Exception("Problem with markdown file creation: " + str(md_file) + " -- " + TECH_ERR + repr(e))
 
 
+
+def process_keep_gnotes(gnotes, overwrite, archive_only, preserve_labels,
+                        skip_existing, text_for_title):
+    pass
 
 def keep_query_convert(keepapi, keepquery, overwrite, archive_only, preserve_labels, skip_existing, text_for_title):
 
-  try:
-      count = 0
-      ccnt = 0
+    try:
+        count = 0
+        ccnt = 0
 
-      if keepquery == "--all":
-        gnotes = keepapi.all()
-      else:
-        if keepquery[0] == "#":
-          gnotes = keepapi.find(labels=[keepapi.findLabel(keepquery[1:])], archived=archive_only, trashed=False)
+        if keepquery == "--all":
+            gnotes = keepapi.all()
         else:
-          gnotes = keepapi.find(query=keepquery, archived=archive_only, trashed=False)
+            if keepquery[0] == "#":
+                gnotes = keepapi.find(labels=[keepapi.findLabel(keepquery[1:])], archived=archive_only, trashed=False)
+            else:
+                gnotes = keepapi.find(query=keepquery, archived=archive_only, trashed=False)
 
-      for gnote in gnotes:
-        note_date = re.sub('[^A-z0-9-]', ' ', str(gnote.timestamps.created).replace(":","").replace(".", "-"))
-        
-        if gnote.title == '':
-          if text_for_title:
-            gnote.title = re.sub('[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', '', gnote.text[0:50]) #.replace(' ',''))
-          else:
-            gnote.title = note_date
+        for gnote in gnotes:
+            note_date = re.sub('[^A-z0-9-]', ' ', str(gnote.timestamps.created).replace(":","").replace(".", "-"))
+
+            if gnote.title == '':
+                if text_for_title:
+                    gnote.title = re.sub('[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', '', gnote.text[0:50]) #.replace(' ',''))
+                else:
+                    gnote.title = note_date
 
 
-        gnote.title = re.sub('[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', ' ', gnote.title[0:99]) #re.sub('[^A-z0-9-]', ' ', gnote.title)[0:99] 
-        #note_text = gnote.text #gnote.text.replace('”','"').replace('“','"').replace("‘","'").replace("’","'").replace('•', "-").replace(u"\u2610", '[ ]').replace(u"\u2611", '[x]').replace(u'\xa0', u' ').replace(u'\u2013', '--').replace(u'\u2014', '--').replace(u'\u2026', '...').replace(u'\u00b1', '+/-')
-  
-        note_label_list = gnote.labels 
-        labels = note_label_list.all()
-        note_labels = ""
-        if preserve_labels:
-          for label in labels:
-            note_labels = note_labels + " #" + str(label)
-        else:
-          for label in labels:
-            note_labels = note_labels + " #" + str(label).replace(' ','-').replace('&','and')
-          note_labels = re.sub('[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-', note_labels) #re.sub('[^A-z0-9-_# ]', '-', note_labels)
-        
-      
-        if archive_only:
-          if gnote.archived and gnote.trashed == False:
-            ccnt = keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_existing)
-          else:
-            ccnt = 0
-        else: 
-          if gnote.archived == False and gnote.trashed == False:
-            ccnt = keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_existing)
+            gnote.title = re.sub('[' + re.escape(''.join(ILLEGAL_FILE_CHARS)) + ']', ' ', gnote.title[0:99]) #re.sub('[^A-z0-9-]', ' ', gnote.title)[0:99]
+            #note_text = gnote.text #gnote.text.replace('”','"').replace('“','"').replace("‘","'").replace("’","'").replace('•', "-").replace(u"\u2610", '[ ]').replace(u"\u2611", '[x]').replace(u'\xa0', u' ').replace(u'\u2013', '--').replace(u'\u2014', '--').replace(u'\u2026', '...').replace(u'\u00b1', '+/-')
 
-        count = count + ccnt
+            note_label_list = gnote.labels
+            labels = note_label_list.all()
+            note_labels = ""
+            if preserve_labels:
+                for label in labels:
+                    note_labels = note_labels + " #" + str(label)
+            else:
+                for label in labels:
+                    note_labels = note_labels + " #" + str(label).replace(' ','-').replace('&','and')
+                note_labels = re.sub('[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-', note_labels) #re.sub('[^A-z0-9-_# ]', '-', note_labels)
 
-      name_list.clear()
-      if overwrite or skip_existing:
-        keep_name_list.clear()
 
-      return (count)
-  except:
-    print ("Error in keep_query_convert()")
-    raise
- 
+            if archive_only:
+                if gnote.archived and gnote.trashed == False:
+                    ccnt = keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_existing)
+                else:
+                    ccnt = 0
+            else:
+                if gnote.archived == False and gnote.trashed == False:
+                    ccnt = keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite, skip_existing)
+
+            count = count + ccnt
+
+        name_list.clear()
+        if overwrite or skip_existing:
+            keep_name_list.clear()
+
+        return (count)
+    except:
+        print ("Error in keep_query_convert()")
+        raise
+
 
 
 #--------------------- UI / CLI ------------------------------
@@ -321,80 +325,80 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only, preserve_lab
 def ui_login(keepapi, defaults, keyring_reset, master_token):
 
     try:
-      
-      userid = defaults.get("google_userid").strip().lower()
-    
-      if userid == USERID_EMPTY:
-        userid = click.prompt('Enter your Google account username', type=str)
-      else:
-        print("Your Google account name in the " + CONFIG_FILE + " file is: " + userid + " -- Welcome!")
-  
-      if keyring_reset:
-        print ("Clearing keyring")
-        keep_clear_keyring(keepapi, userid)
 
-      if master_token:
-        ktoken = master_token
-        keep_save_token(ktoken, userid)
-      else:
-        ktoken = keep_token(keepapi, userid)
-      if ktoken == None:
-        pw = getpass.getpass(prompt='Enter your Google Password: ', stream=None) 
-        print ("\r\n\r\nOne moment...")
+        userid = defaults.get("google_userid").strip().lower()
 
-        ktoken = keep_login(keepapi, userid, pw, keyring_reset)
-        if ktoken:
-          if keyring_reset:
-            print ("You've succesfully logged into Google Keep!")
-          else:
-            print ("You've succesfully logged into Google Keep! Your Keep access token has been securely stored in this computer's keyring.")
-        #else:
-        #  print ("Invalid Google userid or pw! Please try again.")
+        if userid == USERID_EMPTY:
+            userid = click.prompt('Enter your Google account username', type=str)
+        else:
+            print("Your Google account name in the " + CONFIG_FILE + " file is: " + userid + " -- Welcome!")
 
-      else:
-        print ("You've succesfully logged into Google Keep using local keyring access token!")
+        if keyring_reset:
+            print ("Clearing keyring")
+            keep_clear_keyring(keepapi, userid)
 
-      keep_resume(keepapi, ktoken, userid)
-      return (ktoken)
+        if master_token:
+            ktoken = master_token
+            keep_save_token(ktoken, userid)
+        else:
+            ktoken = keep_token(keepapi, userid)
+        if ktoken == None:
+            pw = getpass.getpass(prompt='Enter your Google Password: ', stream=None)
+            print ("\r\n\r\nOne moment...")
+
+            ktoken = keep_login(keepapi, userid, pw, keyring_reset)
+            if ktoken:
+                if keyring_reset:
+                    print ("You've succesfully logged into Google Keep!")
+                else:
+                    print ("You've succesfully logged into Google Keep! Your Keep access token has been securely stored in this computer's keyring.")
+            #else:
+            #  print ("Invalid Google userid or pw! Please try again.")
+
+        else:
+            print ("You've succesfully logged into Google Keep using local keyring access token!")
+
+        keep_resume(keepapi, ktoken, userid)
+        return (ktoken)
 
     except Exception as e:
-      print ("\r\nUsername or password is incorrect (" + repr(e) + ")") 
-      raise
+        print ("\r\nUsername or password is incorrect (" + repr(e) + ")")
+        raise
 
 
 
 def ui_query(keepapi, search_term, overwrite, archive_only, preserve_labels, skip_existing, text_for_title):
 
-  try:
-    if search_term != None:
-        count = keep_query_convert(keepapi, search_term, overwrite, archive_only, preserve_labels, skip_existing, text_for_title)
-        print ("\nTotal converted notes: " + str(count))
-        return
-    else:
-      kquery = "kquery"
-      while kquery:
-        kquery = click.prompt("\r\nEnter a keyword search, label search or '--all' to convert Keep notes to md or '--x' to exit", type=str)
-        if kquery != "--x":
-          count = keep_query_convert(keepapi, kquery, overwrite, archive_only, preserve_labels, skip_existing, text_for_title)
-          print ("\nTotal converted notes: " + str(count))
+    try:
+        if search_term != None:
+            count = keep_query_convert(keepapi, search_term, overwrite, archive_only, preserve_labels, skip_existing, text_for_title)
+            print ("\nTotal converted notes: " + str(count))
+            return
         else:
-          return
-  except Exception as e:
-    print ("Conversion to markdown error - " + repr(e) + " ") 
-    raise
-  
+            kquery = "kquery"
+            while kquery:
+                kquery = click.prompt("\r\nEnter a keyword search, label search or '--all' to convert Keep notes to md or '--x' to exit", type=str)
+                if kquery != "--x":
+                    count = keep_query_convert(keepapi, kquery, overwrite, archive_only, preserve_labels, skip_existing, text_for_title)
+                    print ("\nTotal converted notes: " + str(count))
+                else:
+                    return
+    except Exception as e:
+        print ("Conversion to markdown error - " + repr(e) + " ")
+        raise
+
 
 def ui_welcome_config():
-  try:
-    defaults = load_config()
-    mp = defaults.get("media_path")
-    if ( (":" in mp) or (mp[0] == '/') ):
-      raise ValueError("Media path: '" + mp + "' within your config file - " + CONFIG_FILE + " - must be relative to the output path and cannot start with / or a drive-mount")
-    return defaults
-  except Exception as e:
-    print ("\r\nConfiguration file error - " + CONFIG_FILE + " - " + repr(e) + " ") 
-    raise
-  
+    try:
+        defaults = load_config()
+        mp = defaults.get("media_path")
+        if ( (":" in mp) or (mp[0] == '/') ):
+            raise ValueError("Media path: '" + mp + "' within your config file - " + CONFIG_FILE + " - must be relative to the output path and cannot start with / or a drive-mount")
+        return defaults
+    except Exception as e:
+        print ("\r\nConfiguration file error - " + CONFIG_FILE + " - " + repr(e) + " ")
+        raise
+
 
 
 
@@ -410,25 +414,25 @@ def ui_welcome_config():
 def main(r, o, a, p, s, c, search_term, master_token):
 
 
-  try:
+    try:
 
-    click.echo("\r\nWelcome to Keep it Markdown or KIM!\r\n")
+        click.echo("\r\nWelcome to Keep it Markdown or KIM!\r\n")
 
-    if o and s:
-        print ("Overwrite and Skip flags are not compatible together -- please use one or the other...")
-        exit()
-    
+        if o and s:
+            print ("Overwrite and Skip flags are not compatible together -- please use one or the other...")
+            exit()
 
-    kapi = keep_init()
 
-    ui_login(kapi, ui_welcome_config(), r, master_token)
- 
-    ui_query(kapi, search_term, o, a, p, s, c)
-      
-      
-  except:
-    print ("Could not excute KIM")
- 
+        kapi = keep_init()
+
+        ui_login(kapi, ui_welcome_config(), r, master_token)
+
+        ui_query(kapi, search_term, o, a, p, s, c)
+
+
+    except:
+        print ("Could not excute KIM")
+
 
 
 #Version 0.4.3

--- a/kim.py
+++ b/kim.py
@@ -1,3 +1,4 @@
+from ntpath import join
 import sys
 import os
 import getopt
@@ -11,8 +12,9 @@ import re
 import time
 import configparser
 import click
+import json
 from pathlib import Path
-from collections import namedtuple
+from datetime import datetime
 
 KEEP_CACHE = 'kdata.json'
 KEEP_KEYRING_ID = 'google-keep-token'
@@ -201,28 +203,21 @@ def keep_md_exists(md_file, outpath, note_title, note_date):
     return (note_title)
 
 
-def keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite,
-                      skip_existing):
+def keep_save_md_file(gnote, overwrite, skip_existing):
 
     try:
-
-        md_text = gnote.text.replace(u"\u2610",
-                                     '- [ ]').replace(u"\u2611", ' - [x]')
+        note_labels = gnote.note_labels
+        note_date = gnote.note_date
+        md_text = gnote.md_text
 
         outpath = load_config().get("output_path").rstrip("/")
-        mediapath = load_config().get("media_path").rstrip("/")
-
         if not os.path.exists(outpath):
             os.mkdir(outpath)
-
-        mediapath = outpath + "/" + mediapath + "/"
-        if not os.path.exists(mediapath):
-            os.mkdir(mediapath)
 
         gnote.title = keep_note_name(gnote.title, note_date)
         keep_name_list.append(gnote.title)
 
-        md_file = Path(outpath, gnote.title + ".md")
+        md_file = Path(outpath, gnote.title.replace("/", "-") + ".md")
         if not overwrite:
             if md_file.exists():
                 if skip_existing:
@@ -232,37 +227,119 @@ def keep_save_md_file(keepapi, gnote, note_labels, note_date, overwrite,
                                                  note_date)
                     md_file = Path(outpath, gnote.title + ".md")
 
-        for idx, blob in enumerate(gnote.blobs):
-            try:
-                image_url = keepapi.getMediaLink(blob)
-            except AttributeError as e:
-                if "'NoneType' object has no attribute 'type'" in str(e):
-                    print(f"continuing, despite note {gnote.title} raising:",
-                          repr(e))
-                    continue
-                raise e
-            #print (image_url)
-            image_name = gnote.title + str(idx)
-            blob_file = keep_download_blob(image_url, image_name, mediapath)
-            md_text = blob_file + "\n" + md_text
-
+        lines = md_text.split("\n")
+        found = False
+        for line in lines:
+            if len(line.strip()):
+                found = True
+                break
+        if not found:
+            return
         print(gnote.title)
         print(note_labels)
         print(note_date + "\r\n")
 
         f = open(md_file, "w+", encoding='utf-8', errors="ignore")
+        f.write(f"""---
+updated: ["{str(gnote.timestamps.updated)}"]
+created: ["{str(gnote.timestamps.created)}"]
+---    
+  
+""")
         #f.write(url_to_md(url_to_md(note_text, "http://"), "https://") + "\n")
         f.write(url_to_md(md_text) + "\n")
-        f.write("\n" + note_labels + "\n\n")
-        f.write("Created: " + str(gnote.timestamps.created) +
-                "      Updated: " + str(gnote.timestamps.updated) + "\n\n")
-        f.write("[" + KEEP_NOTE_URL + str(gnote.id) + "](" + KEEP_NOTE_URL +
-                str(gnote.id) + ")\n\n")
+        f.write("\n" + note_labels + "\n")
+        if gnote.id != "unknown":
+            f.write("[" + KEEP_NOTE_URL + str(gnote.id) + "](" +
+                    KEEP_NOTE_URL + str(gnote.id) + ")\n\n")
         f.close
         return (1)
     except Exception as e:
         raise Exception("Problem with markdown file creation: " +
                         str(md_file) + " -- " + TECH_ERR + repr(e))
+
+
+def setup_folders():
+    outpath = load_config().get("output_path").rstrip("/")
+    if not os.path.exists(outpath):
+        os.mkdir(outpath)
+
+    mediapath = load_config().get("media_path").rstrip("/")
+
+    mediapath = outpath + "/" + mediapath + "/"
+    if not os.path.exists(mediapath):
+        os.mkdir(mediapath)
+
+
+class Timestamps:
+    created: datetime
+    updated: datetime
+
+
+class Gnote:
+    id = "unknown"
+    timestamps = Timestamps()
+
+
+def keep_takeout_load(takeout_folder, overwrite, archive_only, preserve_labels,
+                      skip_existing):
+    files = [
+        file for file in os.listdir(takeout_folder) if file.endswith(".json")
+    ]
+    gnotes = []
+    count = 0
+
+    for file in files:
+        gnote = Gnote()
+        data = json.load(open(join(takeout_folder, file), "r"))
+        if "textContent" not in data:
+            data["textContent"] = ""
+        if "labels" not in data:
+            data["labels"] = {}
+
+        ccnt = 0
+        if archive_only:
+            if data["isArchived"] and data["isTrashed"] == False:
+                ccnt = 1
+        else:
+            if data["isArchived"] == False and data["isTrashed"] == False:
+                ccnt = 1
+        setattr(gnote, 'export', False if ccnt == 0 else True)
+
+        md_text = data["textContent"]
+
+        note_labels = "#GoogleKeep"
+        if preserve_labels:
+            for label in data["labels"]:
+                note_labels = note_labels + " #" + str(label["name"])
+        else:
+            for label in data["labels"]:
+                note_labels = note_labels + " #" + str(label["name"]).replace(
+                    ' ', '-').replace('&', 'and')
+            note_labels = re.sub(
+                '[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-',
+                note_labels)  #re.sub('[^A-z0-9-_# ]', '-', note_labels)
+
+        created_at = datetime.fromtimestamp(data["createdTimestampUsec"] /
+                                            1000000)
+        updated_at = datetime.fromtimestamp(data["userEditedTimestampUsec"] /
+                                            1000000)
+        gnote.timestamps.created = created_at
+        gnote.timestamps.updated = updated_at
+        setattr(gnote, 'note_date', str(updated_at)[:19].replace(" ", "T"))
+        setattr(gnote, 'note_labels', note_labels)
+        setattr(gnote, 'title', data["title"])
+        keep_name_list.append(gnote.title)
+
+        setattr(gnote, 'md_text', md_text)
+        count = count + ccnt
+        gnotes.append(gnote)
+
+    name_list.clear()
+    if overwrite or skip_existing:
+        keep_name_list.clear()
+
+    return (gnotes, len(gnotes))
 
 
 def keep_query_convert(keepapi, keepquery, overwrite, archive_only,
@@ -286,6 +363,29 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only,
                                       trashed=False)
 
         for gnote in gnotes:
+
+            md_text = gnote.text.replace(u"\u2610",
+                                         '- [ ]').replace(u"\u2611", ' - [x]')
+            for idx, blob in enumerate(gnote.blobs):
+                try:
+                    image_url = keepapi.getMediaLink(blob)
+                except AttributeError as e:
+                    if "'NoneType' object has no attribute 'type'" in str(e):
+                        print(
+                            f"continuing, despite note {gnote.title} raising:",
+                            repr(e))
+                        continue
+                    raise e
+                #print (image_url)
+                image_name = gnote.title + str(idx)
+                blob_file = keep_download_blob(image_url, image_name,
+                                               mediapath)
+                md_text = blob_file + "\n" + md_text
+                setattr(gnote, 'image_name', image_name)
+                setattr(gnote, 'blob_file', blob_file)
+
+            setattr(gnote, 'md_text', md_text)
+
             note_date = re.sub(
                 '[^A-z0-9-]', ' ',
                 str(gnote.timestamps.created).replace(":",
@@ -318,18 +418,20 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only,
                     '[' + re.escape(''.join(ILLEGAL_TAG_CHARS)) + ']', '-',
                     note_labels)  #re.sub('[^A-z0-9-_# ]', '-', note_labels)
 
+            setattr(gnote, 'note_date', note_date)
+            setattr(gnote, 'note_labels', note_labels)
+
+            setattr(gnote, 'export', False)
             if archive_only:
                 if gnote.archived and gnote.trashed == False:
-                    ccnt = keep_save_md_file(keepapi, gnote, note_labels,
-                                             note_date, overwrite,
-                                             skip_existing)
+                    setattr(gnote, 'export', True)
+                    ccnt = 1
                 else:
                     ccnt = 0
             else:
                 if gnote.archived == False and gnote.trashed == False:
-                    ccnt = keep_save_md_file(keepapi, gnote, note_labels,
-                                             note_date, overwrite,
-                                             skip_existing)
+                    setattr(gnote, 'export', True)
+                    ccnt = 1
 
             count = count + ccnt
 
@@ -337,7 +439,7 @@ def keep_query_convert(keepapi, keepquery, overwrite, archive_only,
         if overwrite or skip_existing:
             keep_name_list.clear()
 
-        return (count)
+        return (gnotes, count)
     except:
         print("Error in keep_query_convert()")
         raise
@@ -397,14 +499,28 @@ def ui_login(keepapi, defaults, keyring_reset, master_token):
         raise
 
 
-def ui_query(keepapi, search_term, overwrite, archive_only, preserve_labels,
-             skip_existing, text_for_title):
+def ui_query(keepapi, takeout_folder, search_term, overwrite, archive_only,
+             preserve_labels, skip_existing, text_for_title):
 
     try:
-        if search_term != None:
-            count = keep_query_convert(keepapi, search_term, overwrite,
-                                       archive_only, preserve_labels,
-                                       skip_existing, text_for_title)
+        setup_folders()
+        if takeout_folder:
+            (gnotes, count) = keep_takeout_load(takeout_folder, overwrite,
+                                                archive_only, preserve_labels,
+                                                skip_existing)
+            for gnote in gnotes:
+                if gnote.export:
+                    keep_save_md_file(gnote, overwrite, skip_existing)
+            print("\nTotal converted notes: " + str(count))
+            return
+        elif search_term != None:
+            (gnotes, count) = keep_query_convert(keepapi, search_term,
+                                                 overwrite, archive_only,
+                                                 preserve_labels,
+                                                 skip_existing, text_for_title)
+            for gnote in gnotes:
+                if gnote.export:
+                    keep_save_md_file(gnote, overwrite, skip_existing)
             print("\nTotal converted notes: " + str(count))
             return
         else:
@@ -414,14 +530,19 @@ def ui_query(keepapi, search_term, overwrite, archive_only, preserve_labels,
                     "\r\nEnter a keyword search, label search or '--all' to convert Keep notes to md or '--x' to exit",
                     type=str)
                 if kquery != "--x":
-                    count = keep_query_convert(keepapi, kquery, overwrite,
-                                               archive_only, preserve_labels,
-                                               skip_existing, text_for_title)
+                    (gnotes,
+                     count) = keep_query_convert(keepapi, kquery, overwrite,
+                                                 archive_only, preserve_labels,
+                                                 skip_existing, text_for_title)
+                    for gnote in gnotes:
+                        if gnote.export:
+                            keep_save_md_file(gnote, overwrite, skip_existing)
                     print("\nTotal converted notes: " + str(count))
                 else:
                     return
     except Exception as e:
         print("Conversion to markdown error - " + repr(e) + " ")
+        print(e)
         raise
 
 
@@ -468,8 +589,11 @@ def ui_welcome_config():
 @click.option('-b',
               '--search-term',
               help="Run in batch mode with a specific Keep search term")
+@click.option('-f',
+              '--takeout-folder',
+              help="Run in batch mode with a specific Keep search term")
 @click.option('-t', '--master-token', help="Log in using master keep token")
-def main(r, o, a, p, s, c, search_term, master_token):
+def main(r, o, a, p, s, c, search_term, takeout_folder, master_token):
 
     try:
 
@@ -483,9 +607,10 @@ def main(r, o, a, p, s, c, search_term, master_token):
 
         kapi = keep_init()
 
-        ui_login(kapi, ui_welcome_config(), r, master_token)
+        if not takeout_folder:
+            ui_login(kapi, ui_welcome_config(), r, master_token)
 
-        ui_query(kapi, search_term, o, a, p, s, c)
+        ui_query(kapi, takeout_folder, search_term, o, a, p, s, c)
 
     except:
         print("Could not excute KIM")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 gkeepapi
 keyring
 click
+yapf
 
 ###### Requirements with Version Specifiers worked with Python 3.7.3 ######`
 #gkeepapi == 0.13.1


### PR DESCRIPTION
NOTE:  This is NOT ready for prime-time at all.  This is more an exploration of if you are interested.

I could not connect KIM to my account due to all the security I put in place.  So, I exported the data from Google Takeout, and sucked in the directory into Markdown.

I struggled with your formatting, so my `main` branch adds `yapf` and reformats your branch using it (no logic changes).  If you do that first, this PR looks better.

I *think* I have one Obsidian specific code in place:

```py
	          f.write(f"""---
	  updated: ["{str(gnote.timestamps.updated)}"]
	  created: ["{str(gnote.timestamps.created)}"]
	  ---    
	    
	  """)
```

I got tired of trying to make it generic and took a shortcut.  If you are interested in this branch, I can clean that up