### PR TITLE
fix: correct succesfully to successfully typo in log messages

### DIFF
--- a/kim.py
+++ b/kim.py
@@ -907,15 +907,15 @@ def ui_login(master_token, opts):
             ktoken = keep.login(pw, opts.reset)
             if ktoken:
                 if opts.reset:
-                    fs.log("You've succesfully logged into Google Keep!", opts.silent_mode)
+                    fs.log("You've Successfully logged into Google Keep!", opts.silent_mode)
                 else:
-                    fs.log("You've succesfully logged into Google Keep! " + 
+                    fs.log("You've Successfully logged into Google Keep! " + 
                         "Your Keep access token has been securely stored in this computer's keyring.", opts.silent_mode)
             #else:
             #  print ("Invalid Google userid or pw! Please try again.")
 
         else:
-            fs.log("You've succesfully logged into Google Keep using " + 
+            fs.log("You've Successfully logged into Google Keep using " + 
                             "local keyring access token!\n", opts.silent_mode)
 
         keep.resume()


### PR DESCRIPTION
Fixes 3 instances of 'succesfully' → 'successfully' typo in user-facing fs.log() calls (lines 910, 912, 918 in kim.py).

Thank you for maintaining this project!